### PR TITLE
Skip datagrams if the PLL was not locked

### DIFF
--- a/driver/src/sick_scan_common.cpp
+++ b/driver/src/sick_scan_common.cpp
@@ -2654,6 +2654,13 @@ namespace sick_scan
                   //ROS_INFO("%F,%F,%u,%u,%F",timestampfloat,timestampfloat_coor,SystemCountTransmit,SystemCountScan,DeltaTime);
                   //TODO Handle return values
 
+                  // Skip this datagram/scan if the PLL is not locked.
+                  // See https://github.com/SICKAG/sick_scan/issues/66#issuecomment-568726277.
+                  if (!bRet) {
+                    dataToProcess = false;
+                    break;
+                  }
+
 #ifdef DEBUG_DUMP_ENABLED
                   double elevationAngleInDeg=elevationAngleInRad = -elevAngleX200 / 200.0;
                   // DataDumper::instance().pushData((double)SystemCountScan, "LAYER", elevationAngleInDeg);


### PR DESCRIPTION
This pull request implements https://github.com/SICKAG/sick_scan/issues/66#issuecomment-568726277 to eventually fix timestamp hiccups we observed with the TIM5xx lidar:

![image](https://user-images.githubusercontent.com/2506837/73084653-a410be80-3ecd-11ea-9abd-0e0721794de7.png)

Completely untested and I am also not sure yet whether this it the right way to do it.

Related Slack thread: https://intermodalics.slack.com/archives/C8D8Z3LAX/p1579206740072900