### PR TITLE
cmake: fix linking order of sick_scan_test executable target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,9 +172,10 @@ add_executable(sick_scan_test
 	driver/src/tinyxml/tinyxmlparser.cpp
 	)
 target_link_libraries(sick_scan_test
-        ${catkin_LIBRARIES}
+        sick_scan_lib
         ${roslib_LIBRARIES}
-        sick_scan_lib)
+        ${catkin_LIBRARIES}
+)
 
 #
 #  Sensor alignment tool


### PR DESCRIPTION
This is important to avoid duplicate symbols if `sick_scan_lib` is built as a static library (`-DBUILD_SHARED_LIBS=OFF`).